### PR TITLE
Utilize reflection to run examples.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   compile "org.eclipse.swt:${swtArtifactName}:${swtVersion}"
   testCompile "junit:junit:4.11"
   testCompile "org.mockito:mockito-all:1.9.5"
+  examplesCompile "org.reflections:reflections:0.9.9-RC1"
 }
 
 findbugs {

--- a/gradle/example.gradle
+++ b/gradle/example.gradle
@@ -24,7 +24,8 @@ tasks.addRule("Pattern: runExample<WidgetName>") { String taskName ->
       ext.widgetName = taskName - "runExample"
 
       classpath = sourceSets.examples.runtimeClasspath
-      main = "com.readytalk.swt.widgets.buttons.${widgetName}Example"
+      main = "com.readytalk.examples.swt.Examples"
+      args "${widgetName}"
 
       if (platform == 'darwin') {
         jvmArgs '-XstartOnFirstThread'

--- a/src/examples/java/com/readytalk/examples/swt/Examples.java
+++ b/src/examples/java/com/readytalk/examples/swt/Examples.java
@@ -1,0 +1,54 @@
+package com.readytalk.examples.swt;
+
+import org.reflections.Reflections;
+import org.reflections.scanners.MethodAnnotationsScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.logging.Logger;
+
+public class Examples {
+  private static final Logger logger = Logger.getLogger("com.readytalk.examples.Example");
+
+  public static void main(String[] args) {
+    if (args.length <= 0) {
+      logger.severe("You must pass a parameter to the Examples class");
+      return;
+    }
+
+    String exampleToRun = args[0];
+
+    Reflections reflections = new Reflections(new ConfigurationBuilder().
+                                                  setUrls(ClasspathHelper.forPackage("com.readytalk.examples")).
+                                                  setScanners(new MethodAnnotationsScanner()));
+    Set<Method> methods = reflections.getMethodsAnnotatedWith(RunnableExample.class);
+
+    for (Method method : methods) {
+      RunnableExample annotation = method.getAnnotation(RunnableExample.class);
+      if (annotation.name().equals(exampleToRun)) {
+        try {
+          method.invoke(null);
+          return;
+        } catch (IllegalAccessException e) {
+          logger.severe("Caught IllegalAccessException");
+          e.printStackTrace();
+        } catch (InvocationTargetException e) {
+          logger.severe("Caught InvocationTargetException");
+          e.printStackTrace();
+        }
+      }
+    }
+
+    logger.severe("Coudn't find requested example " + exampleToRun);
+    StringBuilder validChoices = new StringBuilder();
+    validChoices.append("Valid choices are:\n");
+    for (Method method : methods) {
+      RunnableExample annotation = method.getAnnotation(RunnableExample.class);
+      validChoices.append("    * " + annotation.name() + "\n");
+    }
+    logger.info(validChoices.toString());
+  }
+}

--- a/src/examples/java/com/readytalk/examples/swt/RunnableExample.java
+++ b/src/examples/java/com/readytalk/examples/swt/RunnableExample.java
@@ -1,0 +1,12 @@
+package com.readytalk.examples.swt;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RunnableExample {
+  String name();
+}

--- a/src/examples/java/com/readytalk/examples/swt/widgets/buttons/SquareButtonExample.java
+++ b/src/examples/java/com/readytalk/examples/swt/widgets/buttons/SquareButtonExample.java
@@ -1,5 +1,7 @@
-package com.readytalk.swt.widgets.buttons;
+package com.readytalk.examples.swt.widgets.buttons;
 
+import com.readytalk.examples.swt.RunnableExample;
+import com.readytalk.swt.widgets.buttons.SquareButton;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Image;
@@ -30,7 +32,8 @@ public class SquareButtonExample {
   public static final SquareButton.SquareButtonColorGroup BUTTON_DEFAULT_COLOR_GROUP =
           new SquareButton.SquareButtonColorGroup(WHITE, WHITE, WHITE, OFF_BLACK);
 
-  public static void main(String[] args) {
+  @RunnableExample(name="SquareButton")
+  public static void run() {
     Shell shell = new Shell(DISPLAY);
     shell.setLayout(new FillLayout());
     Composite composite = new Composite(shell, SWT.NONE);

--- a/src/examples/java/com/readytalk/examples/swt/widgets/notifications/BubbleExample.java
+++ b/src/examples/java/com/readytalk/examples/swt/widgets/notifications/BubbleExample.java
@@ -1,5 +1,9 @@
-package com.readytalk.swt.widgets.notifications;
+package com.readytalk.examples.swt.widgets.notifications;
 
+import com.readytalk.examples.swt.RunnableExample;
+import com.readytalk.swt.widgets.notifications.Bubble;
+import com.readytalk.swt.widgets.notifications.BubbleRegistry;
+import com.readytalk.swt.widgets.notifications.BubbleTag;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseEvent;
 import org.eclipse.swt.events.MouseTrackAdapter;
@@ -16,7 +20,8 @@ import org.eclipse.swt.widgets.ProgressBar;
 import org.eclipse.swt.widgets.Shell;
 
 public class BubbleExample {
-  public static void main(String[] args) {
+  @RunnableExample(name="Bubble")
+  public static void run() {
     final Display display = new Display();
     final Shell shell = new Shell(display);
     shell.setLayout(new FillLayout());


### PR DESCRIPTION
This resolves #7.

Could you guys ( @ezweave , @dougborg , @sesteel ) please take a look at this before I merge?

It might seem a bit heavy-handed, but it makes it so that you can simply add new examples (with the annotation) and gradle will automatically see the new example, create a task and allow the user to execute it.
