### PR TITLE
Fixed NullPointer in PopOverShell

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # Project details
 group=com.readytalk
-version=2.1.2-SNAPSHOT
+version=2.1.2
 
 
 # Optimize the build environment

--- a/src/main/java/com/readytalk/swt/widgets/notifications/PopOverShell.java
+++ b/src/main/java/com/readytalk/swt/widgets/notifications/PopOverShell.java
@@ -412,7 +412,7 @@ public abstract class PopOverShell extends Widget implements Fadeable {
   public boolean fadeComplete(int targetAlpha) {
     synchronized (fadeLock) {
       boolean isFadeComplete = false;
-      if (popOverShell.getAlpha() == targetAlpha) {
+      if (popOverShell == null || popOverShell.getAlpha() == targetAlpha) {
         isFadeComplete =  true;
       }
 


### PR DESCRIPTION
Improvements:
- PopOverShell was throwing a NullPointerException in a specific instance, a simple guard appears to work.
