### PR TITLE
Squash stdout/stderr in gh-pages push

### DIFF
--- a/.utility/push-javadoc-to-gh-pages.sh
+++ b/.utility/push-javadoc-to-gh-pages.sh
@@ -2,7 +2,7 @@
 
 if [ "$TRAVIS_REPO_SLUG" == "ReadyTalk/swt-bling" ] && [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
 
-  echo -e "Publishing javadoc...\n"
+  echo "Publishing javadoc..."
 
   cp -R build/docs/javadoc $HOME/javadoc-latest
 
@@ -16,8 +16,9 @@ if [ "$TRAVIS_REPO_SLUG" == "ReadyTalk/swt-bling" ] && [ "$TRAVIS_JDK_VERSION" =
   cp -Rf $HOME/javadoc-latest ./javadoc
   git add -f .
   git commit -m "Lastest javadoc on successful travis build $TRAVIS_BUILD_NUMBER auto-pushed to gh-pages"
-  git push -fq origin gh-pages > /dev/null
-
-  echo -e "Published Javadoc to gh-pages.\n"
-  
+  if ! git push -fq origin gh-pages &> /dev/null; then
+    echo "Error pushing gh-pages to origin. Bad GH_TOKEN? GitHub down?"
+  else
+    echo "Published Javadoc to gh-pages."
+  fi
 fi


### PR DESCRIPTION
Previously if there was a problem communicating to GitHub or if there was an issue with the GH_TOKEN the token would be displayed and stored in Travis. This update hides the token but still indicates the result for Travis.

Tokens are meant to be secret; they should never be logged.

It probably also makes sense to have the script return non-zero on a failed gh-pages push. This would cause the Travis job to fail so I didn't do it because it would change the way the builds work. If others agree then I'll update the pull request.
