### PR TITLE
Fixes buffer overflow in TravisCI OpenJDK6 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: java
 jdk:
 - oraclejdk7
 - openjdk6
+# Workaround for buffer overflow with openjdk6
+# https://github.com/travis-ci/travis-ci/issues/5227
+addons:
+  hosts:
+    - myshorthost
+  hostname: myshorthost
 env:
   global:
   - secure: TO3oA+i1BRv1eTyHlf2oD9v7Mlh+ZRI2qcy6+vbKvWwKhE97eIl24TBrRnivrAYvDSCb7LQbKfYdlylIAz1j2/sm69A3mwjAxRZetekLesRszy/cgc5FDmMh9x9KgOwDfJlVm8Z1uT2UwZ/AfEGFbLFPjHAcp4jbPgdJcUr2SuY=


### PR DESCRIPTION
See: https://github.com/travis-ci/travis-ci/issues/5227