### PR TITLE
Allow TextIconButtons to be clicked programatically

### DIFF
--- a/src/main/java/com/readytalk/swt/widgets/buttons/texticon/TextIconButton.java
+++ b/src/main/java/com/readytalk/swt/widgets/buttons/texticon/TextIconButton.java
@@ -25,6 +25,7 @@ import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.widgets.Canvas;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.TypedListener;
 
 import java.util.Arrays;
 import java.util.LinkedList;
@@ -35,7 +36,6 @@ import java.util.List;
  */
 @Log
 public class TextIconButton extends Canvas {
-  private final List<SelectionListener> selectionListeners = new LinkedList<SelectionListener>();
   private final ColorPalette colorPalette;
   private final ButtonRenderer buttonRenderer;
 
@@ -60,7 +60,6 @@ public class TextIconButton extends Canvas {
     this.buttonRenderer = buttonRenderer;
     this.buttonStyles = buttonStyles;
     this.currentStyle = buttonStyles.getNormal();
-
     initializeBackground();
     addListeners();
   }
@@ -203,10 +202,7 @@ public class TextIconButton extends Canvas {
     event.widget = this;
     event.display = getDisplay();
     event.type = SWT.Selection;
-
-    for (final SelectionListener selectionListener : selectionListeners) {
-      selectionListener.widgetSelected(new SelectionEvent(event));
-    }
+    notifyListeners(SWT.Selection, event);
   }
 
   protected void handlePaintEvent(PaintEvent event) {
@@ -289,7 +285,9 @@ public class TextIconButton extends Canvas {
       SWT.error(SWT.ERROR_NULL_ARGUMENT);
     }
 
-    selectionListeners.add(listener);
+    TypedListener typedListener = new TypedListener(listener);
+    addListener (SWT.Selection,typedListener);
+    addListener (SWT.DefaultSelection,typedListener);
   }
 
   /**
@@ -435,7 +433,8 @@ public class TextIconButton extends Canvas {
       SWT.error(SWT.ERROR_NULL_ARGUMENT);
     }
 
-    this.selectionListeners.remove(listener);
+    removeListener(SWT.Selection, listener);
+    removeListener(SWT.DefaultSelection, listener);
   }
 
   /**

--- a/src/main/java/com/readytalk/swt/widgets/buttons/texticon/TextIconButtonRenderer.java
+++ b/src/main/java/com/readytalk/swt/widgets/buttons/texticon/TextIconButtonRenderer.java
@@ -80,7 +80,7 @@ public class TextIconButtonRenderer implements ButtonRenderer {
     draw();
   }
 
-  protected void draw() {
+  private void setAdvanced() {
     try {
       gc.setAdvanced(true);
       gc.setAntialias(SWT.ON);
@@ -90,6 +90,10 @@ public class TextIconButtonRenderer implements ButtonRenderer {
       // TODO: log this once
       log.log(Level.WARNING, "Unable to set advanced drawing", e);
     }
+  }
+
+  protected void draw() {
+    setAdvanced();
 
     updateSizes();
 
@@ -154,8 +158,9 @@ public class TextIconButtonRenderer implements ButtonRenderer {
     Font font;
     Rectangle bounds;
 
+    boolean wasAdvanced = gc.getAdvanced();
     //Windows 7/under will not render FontAwesome in advanced mode, so disable advanced.
-    if(isWindows7()) {
+    if (wasAdvanced && isWindows7()) {
       gc.setAdvanced(false);
     }
 
@@ -178,8 +183,9 @@ public class TextIconButtonRenderer implements ButtonRenderer {
       drawTextAtLocation(gc, icon.getText(), font,
           getForegroundColor(icon.getColorLabel(), style.getButtonColorEffect()), bounds.x, bounds.y);
     }
-    if(isWindows7()) {
-      gc.setAdvanced(true);
+
+    if (wasAdvanced && isWindows7()) {
+      setAdvanced();
     }
   }
 


### PR DESCRIPTION
Due to custom event management, the TextIconButton could not be clicked programmatically in integration tests.  I updated it to use the base functionality of widgets for event handling.  This allows the buttons to be clicked in code with

button.notifyListeners(SWT.Selection, new Event());

I also hardened the Windows 7 advanced setting so that all paths hit exception handling logic.