### PR TITLE
Disabled advanced mode when drawing text on Windows

### DIFF
--- a/src/main/java/com/readytalk/swt/util/AdvancedGC.java
+++ b/src/main/java/com/readytalk/swt/util/AdvancedGC.java
@@ -1,0 +1,44 @@
+package com.readytalk.swt.util;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTException;
+import org.eclipse.swt.graphics.GC;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class AdvancedGC {
+    protected static final Logger log = Logger.getLogger(AdvancedGC.class.getName());
+    private static boolean loggedAdvanced = false;
+
+    public static void setAdvanced(GC gc, boolean targetSetting) {
+        if (targetSetting) {
+            try {
+                gc.setAdvanced(true);
+                gc.setAntialias(SWT.ON);
+                gc.setTextAntialias(SWT.ON);
+                gc.setInterpolation(SWT.HIGH);
+            } catch (SWTException e) {
+                if (!loggedAdvanced) {
+                    log.log(Level.WARNING, "Unable to set advanced drawing", e);
+                    loggedAdvanced = true;
+                }
+            }
+        } else {
+            gc.setAdvanced(false);
+        }
+
+    }
+
+    /*
+    * Getting an advanced scope allows setting a gc to a different
+    * advanced value for a certain scope
+    * Calling complete on the returned AdvancedScope
+    * will reset the gc to the original advanced value.
+    */
+    public static AdvancedScope advancedScope(GC gc, boolean targetSetting) {
+        return new AdvancedScopeImpl(gc, targetSetting);
+    }
+
+
+}

--- a/src/main/java/com/readytalk/swt/util/AdvancedScope.java
+++ b/src/main/java/com/readytalk/swt/util/AdvancedScope.java
@@ -1,0 +1,9 @@
+package com.readytalk.swt.util;
+
+/*
+ * The Advanced Scope allows setting a gc to advanced for a certain time (scope)
+ * Calling complete will reset the gc to the original advanced value.
+ */
+public interface AdvancedScope {
+    void complete();
+}

--- a/src/main/java/com/readytalk/swt/util/AdvancedScopeImpl.java
+++ b/src/main/java/com/readytalk/swt/util/AdvancedScopeImpl.java
@@ -1,0 +1,29 @@
+package com.readytalk.swt.util;
+
+import org.eclipse.swt.graphics.GC;
+
+import static com.readytalk.swt.util.AdvancedGC.setAdvanced;
+
+class AdvancedScopeImpl implements AdvancedScope {
+    private boolean changed = false;
+    private boolean targetSetting;
+    private boolean initialSetting;
+    private GC gc;
+
+    public AdvancedScopeImpl(GC gc, boolean targetSetting) {
+        this.targetSetting = targetSetting;
+        this.gc = gc;
+        this.initialSetting = gc.getAdvanced();
+        if (initialSetting != targetSetting) {
+            changed = true;
+            setAdvanced(gc, targetSetting);
+        }
+
+    }
+
+    public void complete() {
+        if (changed) {
+            setAdvanced(gc, initialSetting);
+        }
+    }
+}

--- a/src/main/java/com/readytalk/swt/util/ClientOS.java
+++ b/src/main/java/com/readytalk/swt/util/ClientOS.java
@@ -1,0 +1,29 @@
+package com.readytalk.swt.util;
+
+import org.eclipse.swt.SWT;
+
+public class ClientOS {
+    public static boolean isWindows7() {
+        boolean windows7 = false;
+        String swtPlatform = SWT.getPlatform();
+        if(swtPlatform.equals("win32")) {
+            double version;
+            try {
+                version = Float.parseFloat(System.getProperty("os.version"));
+                windows7 = version <= 7.0;
+            } catch (NumberFormatException ex) {
+                windows7 = true;
+            }
+        }
+        return windows7;
+    }
+
+    public static boolean isWindows() {
+        boolean windows = false;
+        String swtPlatform = SWT.getPlatform();
+        if(swtPlatform.equals("win32")) {
+           windows = true;
+        }
+        return windows;
+    }
+}

--- a/src/main/java/com/readytalk/swt/widgets/buttons/SquareButton.java
+++ b/src/main/java/com/readytalk/swt/widgets/buttons/SquareButton.java
@@ -1,7 +1,10 @@
 package com.readytalk.swt.widgets.buttons;
 
+import com.readytalk.swt.util.AdvancedGC;
+import com.readytalk.swt.util.AdvancedScope;
+import com.readytalk.swt.util.ClientOS;
 import com.readytalk.swt.util.ColorFactory;
-import org.eclipse.swt.SWTException;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.accessibility.AccessibleAdapter;
 import org.eclipse.swt.accessibility.AccessibleEvent;
 import org.eclipse.swt.events.DisposeEvent;
@@ -20,7 +23,6 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Canvas;
@@ -32,6 +34,8 @@ import org.eclipse.swt.widgets.TypedListener;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+
+import static com.readytalk.swt.util.AdvancedGC.setAdvanced;
 
 /**
  * The SquareButton class is a simple SWT widget that can be used in place of
@@ -412,15 +416,7 @@ public class SquareButton extends Canvas {
 
     GC gc = paintEvent.gc;
 
-    //try and enable nice looking fonts on windows
-    try {
-      gc.setAdvanced(true);
-      gc.setAntialias(SWT.ON);
-      gc.setTextAntialias(SWT.ON);
-      gc.setInterpolation(SWT.HIGH);
-    } catch (SWTException exception) {
-      log.warning("Couldn't get nice fonts: " + exception.getMessage());
-    }
+    setAdvanced(gc, true);
 
     // add transparency by making the canvas background the same as
     // the parent background (only needed for rounded corners)
@@ -730,7 +726,11 @@ public class SquareButton extends Canvas {
   protected void drawText(GC gc, int x, int y) {
     gc.setFont(font);
     gc.setForeground(currentFontColor);
+    //Advanced font rendering causes errors with some versions of Lato on
+    //Windows, so set advanced to false while drawing test if windows.
+    AdvancedScope scope = AdvancedGC.advancedScope(gc, !ClientOS.isWindows());
     gc.drawText(text, x, y, SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER);
+    scope.complete();
   }
 
 


### PR DESCRIPTION
Setting advanced mode when a user has an older version of Lato installed results in garbled text.  Turning off advanced while drawing the text resolves this issue.  I put in a scoping pattern to remove duplicate code.

This might be a bit overkill (we could just never set advanced on Windows) but will allow drawing icons in Advanced mode on Windows 10 which should be smoother.