### PR TITLE
CU-32: Avoid rendering icon when the icon font has not loaded

### DIFF
--- a/src/main/java/com/readytalk/swt/util/FontFactory.java
+++ b/src/main/java/com/readytalk/swt/util/FontFactory.java
@@ -17,281 +17,283 @@ import java.util.logging.Level;
  * duplicates everywhere; this can greatly decrease the number of fonts we allocate.
  */
 @Log
-public enum FontFactory {;
-  private static final String WINDOWS = "Windows";
-  private static final String SANS_SERIF = "Sans-Serif";
-  private static final String MAC = "Mac";
-  private static final String LUCIDA_GRANDE = "Lucida-Grande";
-  private static final String VERA = "Vera";
-  private static final String OS_NAME = "os.name";
-  private static final int DEFAULT_STYLE = SWT.NORMAL;
-  private static final int FONT_DPI = 72;
+public enum FontFactory {
+    ;
+    private static final String WINDOWS = "Windows";
+    private static final String SANS_SERIF = "Sans-Serif";
+    private static final String MAC = "Mac";
+    private static final String LUCIDA_GRANDE = "Lucida-Grande";
+    private static final String VERA = "Vera";
+    private static final String OS_NAME = "os.name";
+    private static final int DEFAULT_STYLE = SWT.NORMAL;
+    private static final int FONT_DPI = 72;
 
-  private static String defaultName;
-  private static String defaultIconName;
-  private static int defaultSize;
-  private static int defaultIconSize;
+    private static String defaultName;
+    private static String defaultIconName;
+    private static int defaultSize;
+    private static int defaultIconSize;
 
-  static final Map<FontData, Font> fontMap = new HashMap<FontData, Font>();
+    static final Map<FontData, Font> fontMap = new HashMap<FontData, Font>();
 
-  static {
-    setDefaults();
-  }
-
-  @VisibleForTesting
-  static void setDefaults() {
-    String osName = System.getProperty(OS_NAME);
-    if (osName == null || osName.length() == 0 || osName.startsWith(WINDOWS)) {
-      defaultName = SANS_SERIF;
-    } else if (osName.startsWith(MAC)) {
-      defaultName = LUCIDA_GRANDE;
-    } else {
-      defaultName = VERA;
+    static {
+        setDefaults();
     }
 
-    defaultIconName = "FontAwesome";
-
-    defaultSize = 10;
-    defaultIconSize = 25;
-  }
-
-  /**
-   * Sets the font name to be used by default when getting a font when no name is provided
-   *
-   * @param name
-   */
-  public static void setDefaultFontName(String name) {
-    defaultName = name;
-  }
-
-  /**
-   * Sets the icon font name to be used by default when getting an icon font
-   *
-   * @param name
-   */
-  public static void setDefaultIconFontName(String name) {
-    defaultIconName = name;
-  }
-
-  /**
-   * Sets the font size to be used by default when getting a font when no size is provided
-   *
-   * @param size
-   */
-  public static void setDefaultFontSize(int size) {
-    defaultSize = size;
-  }
-
-  /**
-   * Sets the icon font size to be used by default when getting an icon font when no size is provided
-   *
-   * @param size
-   */
-  public static void setDefaultIconFontSize(int size) {
-    defaultIconSize = size;
-  }
-
-  /**
-   * Returns an SWT Font to be used for scalable font based icons at the default size and style
-   *
-   * @return
-   */
-  public static Font getIconFont() {
-    return getIconFont(defaultIconSize);
-  }
-
-  /**
-   * Returns an SWT Font to be used for scalable font based icons at the specified size and default style
-   *
-   * @param size
-   * @return
-   */
-  public static Font getIconFont(int size) {
-    return getFont(Display.getCurrent(), size, DEFAULT_STYLE, defaultIconName) ;
-  }
-
-  /**
-   * Returns an SWT Font with bold style and default size and font name
-   *
-   * @return
-   */
-  public static Font getBold() {
-    return getFont(defaultSize, SWT.BOLD);
-  }
-
-  /**
-   * Returns an SWT Font with the specified size, bold style, and default font name
-   *
-   * @param size
-   * @return
-   */
-  public static Font getBold(int size) {
-    return getFont(size, SWT.BOLD);
-  }
-
-  /**
-   * Returns an SWT Font with italic style and default size and font name
-   *
-   * @return
-   */
-  public static Font getItalic() {
-    return getFont(defaultSize, SWT.ITALIC);
-  }
-
-  /**
-   * Returns an SWT Font with the specified size, italic style, and default font name
-   *
-   * @param size
-   * @return
-   */
-  public static Font getItalic(int size) {
-    return getFont(size, SWT.ITALIC);
-  }
-
-  /**
-   * Gives you a font with the default size, normal style, and default font. Clients
-   * should not dispose the font returned by this function call, as the owner is
-   * FontFactory.
-   *
-   * @return Font
-   */
-  public static Font getFont() {
-    return getFont(Display.getCurrent(), defaultSize, DEFAULT_STYLE, defaultName);
-  }
-
-  /**
-   * Gives you a font with the default size, normal style, and default font. Clients
-   * should not dispose the font returned by this function call, as the owner is
-   * FontFactory.
-   *
-   * @param dev Device object off of which to create the font.
-   * @return Font
-   */
-  public static Font getFont(final Device dev) {
-    return getFont(dev, defaultSize, DEFAULT_STYLE, defaultName);
-  }
-
-  /**
-   * Gives you a font with the specified size, normal style, and default font. Clients
-   * should not dispose the font returned by this function call, as the owner is
-   * FontFactory.
-   *
-   * @param size font point size
-   * @return Font
-   */
-  public static Font getFont(final int size) {
-    return getFont(Display.getCurrent(), size, DEFAULT_STYLE, defaultName);
-  }
-
-  /**
-   * Gives you a font with the specified size, normal style, and default font. Clients
-   * should not dispose the font returned by this function call, as the owner is
-   * FontFactory.
-   *
-   * @param dev Device object off of which to create the font.
-   * @param size font point size
-   * @return Font
-   */
-  public static Font getFont(final Device dev, final int size) {
-    return getFont(dev, size, DEFAULT_STYLE, defaultName);
-  }
-
-  /**
-   * Gives you a font with the specified size, specified style, and default font. Clients
-   * should not dispose the font returned by this function call, as the owner is
-   * FontFactory.
-   *
-   * @param dev Device object off of which to create the font.
-   *
-   * @return Font
-   */
-  public static Font getFont(final Device dev, final int size, final int style) {
-    return getFont(dev, size, style, defaultName);
-  }
-
-  /**
-   * Gives you the default font with the specified size and style. Clients
-   * should not dispose the font returned by this function call, as the owner is
-   * FontFactory.
-   *
-   * @return Font
-   */
-  public static Font getFont(final int size, final int style) {
-    return getFont(Display.getCurrent(), size, style);
-  }
-
-  // converts a "size" metric to the nearest system-dependent
-  // "point" metric - based on DPIs
-  private static int fontPoint(final Device dev, final int size) {
-    int systemDPI = dev.getDPI().y;
-    double ratio = (double) FONT_DPI / systemDPI;
-    return (int) (ratio * size);
-  }
-
-  /**
-   * Gives you a font with the specified size, specified style, and specified font. Clients
-   * should not dispose the font returned by this function call, as the owner is
-   * FontFactory.
-   *
-   * @param dev Device object off of which to create the font.
-   * @return Font
-   */
-  public static Font getFont(final Device dev, final int size, final int style, final String name) {
-    Font font = null;
-    int renderSize = fontPoint(dev, size);
-    final FontData data = new FontData(name, renderSize, style);
-
-    if (fontMap.containsKey(data)) {
-      font = fontMap.get(data);
-    }
-
-    if (font == null || font.isDisposed()) {
-      try {
-        // The requested font was not in the cache so attempt to create it
-        font = new Font(dev, data);
-      } catch (Exception e) {
-        try {
-          // There was a problem creating the requested font, so attempt to fall back to the default name and style
-          log.log(Level.WARNING, "Unable to create requested font", e);
-          font = new Font(dev, defaultName, renderSize, DEFAULT_STYLE);
-        } catch (Exception f) {
-          // There was still a problem so fall back to the default name, style, and size
-          log.log(Level.WARNING, "Still unable to create requested font", e);
-          font = new Font(dev, defaultName, defaultSize, DEFAULT_STYLE);
+    @VisibleForTesting
+    static void setDefaults() {
+        String osName = System.getProperty(OS_NAME);
+        if (osName == null || osName.length() == 0 || osName.startsWith(WINDOWS)) {
+            defaultName = SANS_SERIF;
+        } else if (osName.startsWith(MAC)) {
+            defaultName = LUCIDA_GRANDE;
+        } else {
+            defaultName = VERA;
         }
-      }
 
-      fontMap.put(data, font);
+        defaultIconName = "FontAwesome";
+
+        defaultSize = 10;
+        defaultIconSize = 25;
     }
 
-    return font;
-  }
-
-  /**
-   * Draw text icons at a location based on the style of the button.
-   */
-  public static boolean checkIfFontLoaded(Font font) {
-    final String allegedIconFontName = font.getFontData()[0].getName();
-    // If FontLoader couldn't load FontAwesome, it falls back to setting the icon font to the system default.
-    if (Display.getDefault().getFontList(allegedIconFontName, true).length > 0) {
-      return true;
-    } else {
-      log.warning("Problem loading icon font. Fallback font may not contain matching glyphs.");
-      return false;
-    }
-  }
-
-  /**
-   * Disposes all the fonts and clears the internal storage of fonts. Does not do ref counting,
-   * so use this with care.
-   */
-  public static void disposeAll() {
-    for (Font font : fontMap.values()) {
-      if (font != null && !font.isDisposed()) {
-        font.dispose();
-      }
+    /**
+     * Sets the font name to be used by default when getting a font when no name is provided
+     *
+     * @param name
+     */
+    public static void setDefaultFontName(String name) {
+        defaultName = name;
     }
 
-    fontMap.clear();
-  }
+    /**
+     * Sets the icon font name to be used by default when getting an icon font
+     *
+     * @param name
+     */
+    public static void setDefaultIconFontName(String name) {
+        defaultIconName = name;
+    }
+
+    /**
+     * Sets the font size to be used by default when getting a font when no size is provided
+     *
+     * @param size
+     */
+    public static void setDefaultFontSize(int size) {
+        defaultSize = size;
+    }
+
+    /**
+     * Sets the icon font size to be used by default when getting an icon font when no size is provided
+     *
+     * @param size
+     */
+    public static void setDefaultIconFontSize(int size) {
+        defaultIconSize = size;
+    }
+
+    /**
+     * Returns an SWT Font to be used for scalable font based icons at the default size and style
+     *
+     * @return
+     */
+    public static Font getIconFont() {
+        return getIconFont(defaultIconSize);
+    }
+
+    /**
+     * Returns an SWT Font to be used for scalable font based icons at the specified size and default style
+     *
+     * @param size
+     * @return
+     */
+    public static Font getIconFont(int size) {
+        return getFont(Display.getCurrent(), size, DEFAULT_STYLE, defaultIconName);
+    }
+
+    /**
+     * Returns an SWT Font with bold style and default size and font name
+     *
+     * @return
+     */
+    public static Font getBold() {
+        return getFont(defaultSize, SWT.BOLD);
+    }
+
+    /**
+     * Returns an SWT Font with the specified size, bold style, and default font name
+     *
+     * @param size
+     * @return
+     */
+    public static Font getBold(int size) {
+        return getFont(size, SWT.BOLD);
+    }
+
+    /**
+     * Returns an SWT Font with italic style and default size and font name
+     *
+     * @return
+     */
+    public static Font getItalic() {
+        return getFont(defaultSize, SWT.ITALIC);
+    }
+
+    /**
+     * Returns an SWT Font with the specified size, italic style, and default font name
+     *
+     * @param size
+     * @return
+     */
+    public static Font getItalic(int size) {
+        return getFont(size, SWT.ITALIC);
+    }
+
+    /**
+     * Gives you a font with the default size, normal style, and default font. Clients
+     * should not dispose the font returned by this function call, as the owner is
+     * FontFactory.
+     *
+     * @return Font
+     */
+    public static Font getFont() {
+        return getFont(Display.getCurrent(), defaultSize, DEFAULT_STYLE, defaultName);
+    }
+
+    /**
+     * Gives you a font with the default size, normal style, and default font. Clients
+     * should not dispose the font returned by this function call, as the owner is
+     * FontFactory.
+     *
+     * @param dev Device object off of which to create the font.
+     * @return Font
+     */
+    public static Font getFont(final Device dev) {
+        return getFont(dev, defaultSize, DEFAULT_STYLE, defaultName);
+    }
+
+    /**
+     * Gives you a font with the specified size, normal style, and default font. Clients
+     * should not dispose the font returned by this function call, as the owner is
+     * FontFactory.
+     *
+     * @param size font point size
+     * @return Font
+     */
+    public static Font getFont(final int size) {
+        return getFont(Display.getCurrent(), size, DEFAULT_STYLE, defaultName);
+    }
+
+    /**
+     * Gives you a font with the specified size, normal style, and default font. Clients
+     * should not dispose the font returned by this function call, as the owner is
+     * FontFactory.
+     *
+     * @param dev  Device object off of which to create the font.
+     * @param size font point size
+     * @return Font
+     */
+    public static Font getFont(final Device dev, final int size) {
+        return getFont(dev, size, DEFAULT_STYLE, defaultName);
+    }
+
+    /**
+     * Gives you a font with the specified size, specified style, and default font. Clients
+     * should not dispose the font returned by this function call, as the owner is
+     * FontFactory.
+     *
+     * @param dev Device object off of which to create the font.
+     * @return Font
+     */
+    public static Font getFont(final Device dev, final int size, final int style) {
+        return getFont(dev, size, style, defaultName);
+    }
+
+    /**
+     * Gives you the default font with the specified size and style. Clients
+     * should not dispose the font returned by this function call, as the owner is
+     * FontFactory.
+     *
+     * @return Font
+     */
+    public static Font getFont(final int size, final int style) {
+        return getFont(Display.getCurrent(), size, style);
+    }
+
+    // converts a "size" metric to the nearest system-dependent
+    // "point" metric - based on DPIs
+    private static int fontPoint(final Device dev, final int size) {
+        int systemDPI = dev.getDPI().y;
+        double ratio = (double) FONT_DPI / systemDPI;
+        return (int) (ratio * size);
+    }
+
+    /**
+     * Gives you a font with the specified size, specified style, and specified font. Clients
+     * should not dispose the font returned by this function call, as the owner is
+     * FontFactory.
+     *
+     * @param dev Device object off of which to create the font.
+     * @return Font
+     */
+    public static Font getFont(final Device dev, final int size, final int style, final String name) {
+        Font font = null;
+        int renderSize = fontPoint(dev, size);
+        final FontData data = new FontData(name, renderSize, style);
+
+        if (fontMap.containsKey(data)) {
+            font = fontMap.get(data);
+        }
+
+        if (font == null || font.isDisposed()) {
+            try {
+                // The requested font was not in the cache so attempt to create it
+                font = new Font(dev, data);
+            } catch (Exception e) {
+                try {
+                    // There was a problem creating the requested font, so attempt to fall back to the default name and style
+                    log.log(Level.WARNING, "Unable to create requested font", e);
+                    font = new Font(dev, defaultName, renderSize, DEFAULT_STYLE);
+                } catch (Exception f) {
+                    // There was still a problem so fall back to the default name, style, and size
+                    log.log(Level.WARNING, "Still unable to create requested font", e);
+                    font = new Font(dev, defaultName, defaultSize, DEFAULT_STYLE);
+                }
+            }
+
+            fontMap.put(data, font);
+        }
+
+        return font;
+    }
+
+    public static String getGlyphs(String)
+
+    /**
+     * Draw text icons at a location based on the style of the button.
+     */
+    public static boolean checkIfFontLoaded(Font font) {
+        final String allegedIconFontName = font.getFontData()[0].getName();
+        // If FontLoader couldn't load FontAwesome, it falls back to setting the icon font to the system default.
+        if (Display.getDefault().getFontList(allegedIconFontName, true).length > 0) {
+            return true;
+        } else {
+            log.warning("Problem loading icon font. Fallback font may not contain matching glyphs.");
+            return false;
+        }
+    }
+
+    /**
+     * Disposes all the fonts and clears the internal storage of fonts. Does not do ref counting,
+     * so use this with care.
+     */
+    public static void disposeAll() {
+        for (Font font : fontMap.values()) {
+            if (font != null && !font.isDisposed()) {
+                font.dispose();
+            }
+        }
+
+        fontMap.clear();
+    }
 }

--- a/src/main/java/com/readytalk/swt/util/FontFactory.java
+++ b/src/main/java/com/readytalk/swt/util/FontFactory.java
@@ -268,6 +268,20 @@ public enum FontFactory {;
   }
 
   /**
+   * Draw text icons at a location based on the style of the button.
+   */
+  public static boolean checkIfFontLoaded(Font font) {
+    final String allegedIconFontName = font.getFontData()[0].getName();
+    // If FontLoader couldn't load FontAwesome, it falls back to setting the icon font to the system default.
+    if (Display.getDefault().getFontList(allegedIconFontName, true).length > 0) {
+      return true;
+    } else {
+      log.warning("Problem loading icon font. Fallback font may not contain matching glyphs.");
+      return false;
+    }
+  }
+
+  /**
    * Disposes all the fonts and clears the internal storage of fonts. Does not do ref counting,
    * so use this with care.
    */

--- a/src/main/java/com/readytalk/swt/widgets/buttons/texticon/TextIconButtonRenderer.java
+++ b/src/main/java/com/readytalk/swt/widgets/buttons/texticon/TextIconButtonRenderer.java
@@ -128,22 +128,9 @@ public class TextIconButtonRenderer implements ButtonRenderer {
   }
 
   /**
-   * Draw text icons at a location based on the style of the button.
-   */
-  protected void drawIconText() {
-    final String allegedIconFontName = FontFactory.getIconFont().getFontData()[0].getName();
-    // If FontLoader couldn't load FontAwesome, it falls back to setting the icon font to the system default.
-    if(Display.getDefault().getFontList(allegedIconFontName, true).length > 0){
-      renderIconText();
-    } else {
-      log.warning("Problem loading icon font. Fallback font may not contain matching glyphs.");
-    }
-  }
-
-  /**
    * Draw text icons at a location based on the style of the button
    */
-  protected void renderIconText() {
+  protected void drawIconText() {
       final int spacing = textSize.y > 0 ? style.getSpacing() : 0;
 
       Font font;
@@ -153,11 +140,13 @@ public class TextIconButtonRenderer implements ButtonRenderer {
       AdvancedScope scope = AdvancedGC.advancedScope(gc, !isWindows7());
       // First we draw the drop shadows for each TextIcon layer, if necessary
       if (isIconDropShadowStyle(style.getButtonEffects())) {
-        for (TextIcon icon : button.getTextIcons()) {
-          font = FontFactory.getIconFont(icon.getFontSize());
-          bounds = getIconTextBounds(icon, size.x, size.y, textSize, spacing);
-          drawTextAtLocation(gc, icon.getText(), font, getForegroundColor(icon.getColorLabel(), ButtonColorEffect.DARKEN),
-                  bounds.x + SHADOW_OFFSET, bounds.y + SHADOW_OFFSET);
+        if (FontFactory.checkIfFontLoaded(FontFactory.getIconFont())) {
+          for (TextIcon icon : button.getTextIcons()) {
+            font = FontFactory.getIconFont(icon.getFontSize());
+            bounds = getIconTextBounds(icon, size.x, size.y, textSize, spacing);
+            drawTextAtLocation(gc, icon.getText(), font, getForegroundColor(icon.getColorLabel(),
+                    ButtonColorEffect.DARKEN), bounds.x + SHADOW_OFFSET, bounds.y + SHADOW_OFFSET);
+          }
         }
       }
 

--- a/src/main/java/com/readytalk/swt/widgets/buttons/texticon/TextIconButtonRenderer.java
+++ b/src/main/java/com/readytalk/swt/widgets/buttons/texticon/TextIconButtonRenderer.java
@@ -27,377 +27,376 @@ import static com.readytalk.swt.util.ClientOS.isWindows7;
  */
 @Log
 public class TextIconButtonRenderer implements ButtonRenderer {
-  private static final int SHADOW_OFFSET = 1;
+    private static final int SHADOW_OFFSET = 1;
 
-  protected TextIconButton button;
-  protected ButtonStyle style;
-  protected GC gc;
+    protected TextIconButton button;
+    protected ButtonStyle style;
+    protected GC gc;
 
-  private Point size;
-  private Point textSize;
-  private Point textIconSize;
+    private Point size;
+    private Point textSize;
+    private Point textIconSize;
 
-  @Override
-  public void drawNormal(GC gc, TextIconButton button) {
-    style = button.getButtonStyles().getNormal();
-    this.gc = gc;
-    this.button = button;
-    draw();
-  }
-
-  @Override
-  public void drawHovered(GC gc, TextIconButton button) {
-    style = button.getButtonStyles().getHover();
-    this.gc = gc;
-    this.button = button;
-    draw();
-  }
-
-  @Override
-  public void drawDisabled(GC gc, TextIconButton button) {
-    style = button.getButtonStyles().getDisabled();
-    this.gc = gc;
-    this.button = button;
-    draw();
-  }
-
-  @Override
-  public void drawSelected(GC gc, TextIconButton button) {
-    style = button.getButtonStyles().getSelected();
-    this.gc = gc;
-    this.button = button;
-    draw();
-  }
-
-  @Override
-  public void drawSelectedHovered(GC gc, TextIconButton button) {
-    style = button.getButtonStyles().getSelectedHovered();
-    this.gc = gc;
-    this.button = button;
-    draw();
-  }
-
-  @Override
-  public void drawClicked(GC gc, TextIconButton button) {
-    style = button.getButtonStyles().getClicked();
-    this.gc = gc;
-    this.button = button;
-    draw();
-  }
-
-  protected void draw() {
-    setAdvanced(gc, true);
-
-    updateSizes();
-
-    drawBackground();
-    drawBorder();
-    drawIconText();
-    drawText();
-  }
-
-  private void updateSizes() {
-    final Rectangle clientArea = button.getClientArea();
-
-    textSize = computeTextSize();
-    textIconSize = computeTextIconSize();
-
-    // If we don't have a usable client area from the parent then use the computed minimum size
-    size = (clientArea.width > 0 && clientArea.height > 0) ?
-        new Point(clientArea.width, clientArea.height) :
-        new Point(computeMinimumWidth(textSize.x, textIconSize.x), computeMinimumHeight(textSize.y, textIconSize.y));
-  }
-
-  protected void drawBackground() {
-    gc.setBackground(button.getBackground());
-    gc.fillRectangle(0, 0, size.x, size.y);
-    gc.setBackground(getBackgroundColor(style.getBackgroundColor(), style.getButtonColorEffect()));
-    gc.fillRoundRectangle(0, 0, size.x, size.y, style.getRadius(), style.getRadius());
-  }
-
-  protected void drawBorder() {
-    if (isBorderStyle()) {
-      gc.setForeground(getForegroundColor(style.getBorderColor(), style.getButtonColorEffect()));
-      gc.setLineWidth(style.getBorderWidth());
-
-      // The border coordinates are the center of the border width so we divide in half to get the center
-      gc.drawRoundRectangle(style.getBorderWidth() / 2, style.getBorderWidth() / 2,
-          size.x - Math.max(style.getBorderWidth() / 2, style.getBorderWidth()),
-          size.y - Math.max(style.getBorderWidth() / 2, style.getBorderWidth()), style.getRadius(), style.getRadius());
+    @Override
+    public void drawNormal(GC gc, TextIconButton button) {
+        style = button.getButtonStyles().getNormal();
+        this.gc = gc;
+        this.button = button;
+        draw();
     }
-  }
 
-  /**
-   * Draw text icons at a location based on the style of the button
-   */
-  protected void drawIconText() {
-      final int spacing = textSize.y > 0 ? style.getSpacing() : 0;
+    @Override
+    public void drawHovered(GC gc, TextIconButton button) {
+        style = button.getButtonStyles().getHover();
+        this.gc = gc;
+        this.button = button;
+        draw();
+    }
 
-      Font font;
-      Rectangle bounds;
+    @Override
+    public void drawDisabled(GC gc, TextIconButton button) {
+        style = button.getButtonStyles().getDisabled();
+        this.gc = gc;
+        this.button = button;
+        draw();
+    }
 
-      //Windows 7/under will not render FontAwesome in advanced mode, so disable advanced.
-      AdvancedScope scope = AdvancedGC.advancedScope(gc, !isWindows7());
-      // First we draw the drop shadows for each TextIcon layer, if necessary
-      if (isIconDropShadowStyle(style.getButtonEffects())) {
-        if (FontFactory.checkIfFontLoaded(FontFactory.getIconFont())) {
-          for (TextIcon icon : button.getTextIcons()) {
-            font = FontFactory.getIconFont(icon.getFontSize());
-            bounds = getIconTextBounds(icon, size.x, size.y, textSize, spacing);
-            drawTextAtLocation(gc, icon.getText(), font, getForegroundColor(icon.getColorLabel(),
-                    ButtonColorEffect.DARKEN), bounds.x + SHADOW_OFFSET, bounds.y + SHADOW_OFFSET);
-          }
+    @Override
+    public void drawSelected(GC gc, TextIconButton button) {
+        style = button.getButtonStyles().getSelected();
+        this.gc = gc;
+        this.button = button;
+        draw();
+    }
+
+    @Override
+    public void drawSelectedHovered(GC gc, TextIconButton button) {
+        style = button.getButtonStyles().getSelectedHovered();
+        this.gc = gc;
+        this.button = button;
+        draw();
+    }
+
+    @Override
+    public void drawClicked(GC gc, TextIconButton button) {
+        style = button.getButtonStyles().getClicked();
+        this.gc = gc;
+        this.button = button;
+        draw();
+    }
+
+    protected void draw() {
+        setAdvanced(gc, true);
+
+        updateSizes();
+
+        drawBackground();
+        drawBorder();
+        drawIconText();
+        drawText();
+    }
+
+    private void updateSizes() {
+        final Rectangle clientArea = button.getClientArea();
+
+        textSize = computeTextSize();
+        textIconSize = computeTextIconSize();
+
+        // If we don't have a usable client area from the parent then use the computed minimum size
+        size = (clientArea.width > 0 && clientArea.height > 0) ?
+                new Point(clientArea.width, clientArea.height) :
+                new Point(computeMinimumWidth(textSize.x, textIconSize.x), computeMinimumHeight(textSize.y, textIconSize.y));
+    }
+
+    protected void drawBackground() {
+        gc.setBackground(button.getBackground());
+        gc.fillRectangle(0, 0, size.x, size.y);
+        gc.setBackground(getBackgroundColor(style.getBackgroundColor(), style.getButtonColorEffect()));
+        gc.fillRoundRectangle(0, 0, size.x, size.y, style.getRadius(), style.getRadius());
+    }
+
+    protected void drawBorder() {
+        if (isBorderStyle()) {
+            gc.setForeground(getForegroundColor(style.getBorderColor(), style.getButtonColorEffect()));
+            gc.setLineWidth(style.getBorderWidth());
+
+            // The border coordinates are the center of the border width so we divide in half to get the center
+            gc.drawRoundRectangle(style.getBorderWidth() / 2, style.getBorderWidth() / 2,
+                    size.x - Math.max(style.getBorderWidth() / 2, style.getBorderWidth()),
+                    size.y - Math.max(style.getBorderWidth() / 2, style.getBorderWidth()), style.getRadius(), style.getRadius());
         }
-      }
-
-      // TextIcons can be layered so we loop over them and draw them in place
-      for (TextIcon icon : button.getTextIcons()) {
-        font = FontFactory.getIconFont(icon.getFontSize());
-        bounds = getIconTextBounds(icon, size.x, size.y, textSize, spacing);
-        drawTextAtLocation(gc, icon.getText(), font,
-                getForegroundColor(icon.getColorLabel(), style.getButtonColorEffect()), bounds.x, bounds.y);
-      }
-
-      scope.complete();
-  }
-
-  private Rectangle getIconTextBounds(TextIcon icon, int width, int height, Point textSize, int spacing) {
-    // TODO: cache these locations if not changing
-    final String text = icon.getText();
-    final Font font = FontFactory.getIconFont(icon.getFontSize());
-    final Point iconTextSize = getTextExtent(button, text, font);
-    int x, y;
-
-    if (isRowStyle()) {
-      // Centered vertically, centered horizontally with the button text and spacing (ignores margin/border/etc.)
-      y = height / 2 - iconTextSize.y / 2;
-      int contentWidth = textSize.x + iconTextSize.x + spacing;
-      x = width / 2 - contentWidth / 2;
-    } else {
-      // Centered horizontally, centered vertically with the button text and spacing (ignores margin/border/etc.)
-      x = width / 2 - iconTextSize.x / 2;
-      int contentHeight = textSize.y + iconTextSize.y + spacing;
-      y = height / 2 - contentHeight / 2;
     }
 
-    return new Rectangle(x + icon.getXOffset(), y + icon.getYOffset(), iconTextSize.x, iconTextSize.y);
-  }
+    /**
+     * Draw text icons at a location based on the style of the button
+     */
+    protected void drawIconText() {
+        final int spacing = textSize.y > 0 ? style.getSpacing() : 0;
 
-  /**
-   * Draw text centered horizontally and centered vertically equal with the icon text but below
-   */
-  protected void drawText() {
-    if (button.getText() != null) {
-      //Advanced font rendering causes errors with some versions of Lato on
-      //Windows, so set advanced to false while drawing test if windows.
-      AdvancedScope scope = AdvancedGC.advancedScope(gc, !ClientOS.isWindows());
-      final int spacing = textIconSize.y > 0 ? style.getSpacing() : 0;
-      final Point contentSize = new Point(textSize.x + textIconSize.x + spacing, textSize.y + textIconSize.y + spacing);
+        Font font;
+        Rectangle bounds;
 
-      final Rectangle bounds = getTextBounds(size.x, size.y, contentSize.x, contentSize.y, textSize, textIconSize,
-          spacing);
+        if (FontFactory.checkIfFontLoaded(FontFactory.getIconFont())) {
+            //Windows 7/under will not render FontAwesome in advanced mode, so disable advanced.
+            AdvancedScope scope = AdvancedGC.advancedScope(gc, !isWindows7());
+            // First we draw the drop shadows for each TextIcon layer, if necessary
+            if (isIconDropShadowStyle(style.getButtonEffects())) {
 
-      if (isTextDropShadowStyle(style.getButtonEffects())) {
-        drawTextAtLocation(gc, button.getText(), style.getFont(),
-            getForegroundColor(style.getFontColor(), ButtonColorEffect.DESATURATE), bounds.x + SHADOW_OFFSET,
-            bounds.y + SHADOW_OFFSET);
-      }
-
-      drawTextAtLocation(gc, button.getText(), style.getFont(),
-          getForegroundColor(style.getFontColor(), style.getButtonColorEffect()), bounds.x, bounds.y);
-      scope.complete();
-    }
-  }
-
-  private Rectangle getTextBounds(int width, int height, int contentWidth, int contentHeight, Point textSize,
-      Point iconTextSize, int spacing) {
-    // TODO: cache these locations if not changing
-    int x, y;
-
-    if (isRowStyle()) {
-      // Centered vertically, centered horizontally with the icon text and spacing
-      x = width / 2 - contentWidth / 2 + iconTextSize.x + spacing;
-      y = height / 2 - textSize.y / 2;
-    } else {
-      // Centered horizontally, centered vertically with the icon text and spacing
-      x = width / 2 - textSize.x / 2;
-      y = height / 2 - contentHeight / 2 + iconTextSize.y + spacing;
+                for (TextIcon icon : button.getTextIcons()) {
+                    font = FontFactory.getIconFont(icon.getFontSize());
+                    bounds = getIconTextBounds(icon, size.x, size.y, textSize, spacing);
+                    drawTextAtLocation(gc, icon.getText(), font, getForegroundColor(icon.getColorLabel(),
+                            ButtonColorEffect.DARKEN), bounds.x + SHADOW_OFFSET, bounds.y + SHADOW_OFFSET);
+                }
+            }
+            // TextIcons can be layered so we loop over them and draw them in place
+            for (TextIcon icon : button.getTextIcons()) {
+                font = FontFactory.getIconFont(icon.getFontSize());
+                bounds = getIconTextBounds(icon, size.x, size.y, textSize, spacing);
+                drawTextAtLocation(gc, icon.getText(), font,
+                        getForegroundColor(icon.getColorLabel(), style.getButtonColorEffect()), bounds.x, bounds.y);
+            }
+            scope.complete();
+        }
     }
 
-    return new Rectangle(x, y, textSize.x, textSize.y);
-  }
+    private Rectangle getIconTextBounds(TextIcon icon, int width, int height, Point textSize, int spacing) {
+        // TODO: cache these locations if not changing
+        final String text = icon.getText();
+        final Font font = FontFactory.getIconFont(icon.getFontSize());
+        final Point iconTextSize = getTextExtent(button, text, font);
+        int x, y;
 
-  protected static void drawTextAtLocation(GC gc, String text, Font font, Color color, int x, int y) {
-    gc.setFont(font);
-    gc.setForeground(color);
-    gc.drawText(text, x, y, SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER);
-  }
+        if (isRowStyle()) {
+            // Centered vertically, centered horizontally with the button text and spacing (ignores margin/border/etc.)
+            y = height / 2 - iconTextSize.y / 2;
+            int contentWidth = textSize.x + iconTextSize.x + spacing;
+            x = width / 2 - contentWidth / 2;
+        } else {
+            // Centered horizontally, centered vertically with the button text and spacing (ignores margin/border/etc.)
+            x = width / 2 - iconTextSize.x / 2;
+            int contentHeight = textSize.y + iconTextSize.y + spacing;
+            y = height / 2 - contentHeight / 2;
+        }
 
-  /**
-   * Returns the preferred size of the receiver
-   *
-   * @param button
-   * @return
-   */
-  @Override
-  public Point computeSize(TextIconButton button) {
-    this.button = button;
-    this.style = button.getCurrentStyle();
-
-    updateSizes();
-
-    return size;
-  }
-
-  private int computeMinimumHeight(int textHeight, int iconTextHeight) {
-    int spacing = (textHeight > 0 && iconTextHeight > 0) ? style.getSpacing() : 0;
-    int baseHeight = 2 * style.getMargin() + 2 * style.getBorderWidth() + spacing;
-    int contentHeight = isRowStyle() ? Math.max(textHeight, iconTextHeight) : textHeight + iconTextHeight;
-    return baseHeight + contentHeight;
-  }
-
-  private int computeMinimumWidth(int textWidth, int iconTextWidth) {
-    int spacing = (textWidth > 0 && iconTextWidth > 0) ? style.getSpacing() : 0;
-    int baseWidth = 2 * style.getBorderWidth() + 2 * style.getMargin();
-    int contentWidth = isRowStyle() ? textWidth + iconTextWidth + spacing : Math.max(textWidth, iconTextWidth);
-    return baseWidth + contentWidth;
-  }
-
-  private Point computeTextSize() {
-    String text = button.getText();
-    return (text != null) ? getTextExtent(button, text, style.getFont()) : new Point(0, 0);
-  }
-
-  /**
-   * Returns the estimated size of the painted text icon.
-   * <p>
-   * Note: the current assumption is that the icon is centered and not offset
-   *
-   * @return
-   */
-  private Point computeTextIconSize() {
-    Point max = new Point(0, 0);
-    Point current;
-
-    for (TextIcon icon : button.getTextIcons()) {
-      current = getTextExtent(button, icon.getText(), FontFactory.getIconFont(icon.getFontSize()));
-
-      if (current.x > max.x) {
-        max.x = current.x;
-      }
-
-      if (current.y > max.y) {
-        max.y = current.y;
-      }
+        return new Rectangle(x + icon.getXOffset(), y + icon.getYOffset(), iconTextSize.x, iconTextSize.y);
     }
 
-    return max;
-  }
+    /**
+     * Draw text centered horizontally and centered vertically equal with the icon text but below
+     */
+    protected void drawText() {
+        if (button.getText() != null) {
+            //Advanced font rendering causes errors with some versions of Lato on
+            //Windows, so set advanced to false while drawing test if windows.
+            AdvancedScope scope = AdvancedGC.advancedScope(gc, !ClientOS.isWindows());
+            final int spacing = textIconSize.y > 0 ? style.getSpacing() : 0;
+            final Point contentSize = new Point(textSize.x + textIconSize.x + spacing, textSize.y + textIconSize.y + spacing);
 
-  /**
-   * Returns the dimensions of the specified text in the given font
-   *
-   * @param button
-   * @param text
-   * @param font
-   * @return
-   */
-  protected Point getTextExtent(TextIconButton button, String text, Font font) {
-    final GC gc = new GC(button);
-    gc.setFont(font);
+            final Rectangle bounds = getTextBounds(size.x, size.y, contentSize.x, contentSize.y, textSize, textIconSize,
+                    spacing);
 
-    final Point size = gc.textExtent(text, SWT.DRAW_DELIMITER);
-    gc.dispose();
+            if (isTextDropShadowStyle(style.getButtonEffects())) {
+                drawTextAtLocation(gc, button.getText(), style.getFont(),
+                        getForegroundColor(style.getFontColor(), ButtonColorEffect.DESATURATE), bounds.x + SHADOW_OFFSET,
+                        bounds.y + SHADOW_OFFSET);
+            }
 
-    return size;
-  }
-
-  private boolean isBorderStyle() {
-    return style.getButtonEffects().contains(ButtonEffect.BORDER);
-  }
-
-  private boolean isRowStyle() {
-    // The row button style is the default if none is specified
-    return style.getButtonEffects().contains(ButtonEffect.ROW) || !style.getButtonEffects()
-        .contains(ButtonEffect.COLUMN);
-  }
-
-  private boolean isColumnStyle() {
-    return style.getButtonEffects().contains(ButtonEffect.COLUMN);
-  }
-
-  private boolean isTextDropShadowStyle(Set<ButtonEffect> buttonEffects) {
-    return buttonEffects.contains(ButtonEffect.TEXT_DROP_SHADOW);
-  }
-
-  private boolean isIconDropShadowStyle(Set<ButtonEffect> buttonEffects) {
-    return buttonEffects.contains(ButtonEffect.ICON_DROP_SHADOW);
-  }
-
-  private Color getBackgroundColor(String colorLabel, ButtonColorEffect buttonEffect) {
-    ColorEffect colorEffect = ColorEffect.NONE;
-
-    switch (buttonEffect) {
-    case BRIGHTEN:
-    case BRIGHTEN_BACKGROUND:
-      colorEffect = ColorEffect.BRIGHTEN;
-      break;
-    case DARKEN:
-    case DARKEN_BACKGROUND:
-    case BRIGHTEN_FOREGROUND_DARKEN_BACKGROUND:
-      colorEffect = ColorEffect.DARKEN;
-      break;
-    case DESATURATE:
-    case DESATURATE_BACKGROUND:
-      colorEffect = ColorEffect.DESATURATE;
-      break;
-    case SHIFT:
-    case SHIFT_BACKGROUND:
-      colorEffect = ColorEffect.SHIFT;
-      break;
-    case NONE:
-    case BRIGHTEN_FOREGROUND:
-    case DARKEN_FOREGROUND:
-    case DESATURATE_FOREGROUND:
-      // No background effect
-      break;
-    default:
-      log.warning("Unknown button effect: " + buttonEffect);
+            drawTextAtLocation(gc, button.getText(), style.getFont(),
+                    getForegroundColor(style.getFontColor(), style.getButtonColorEffect()), bounds.x, bounds.y);
+            scope.complete();
+        }
     }
 
-    return button.getColorPalette().getColorWithEffect(colorLabel, colorEffect);
-  }
+    private Rectangle getTextBounds(int width, int height, int contentWidth, int contentHeight, Point textSize,
+                                    Point iconTextSize, int spacing) {
+        // TODO: cache these locations if not changing
+        int x, y;
 
-  private Color getForegroundColor(String colorLabel, ButtonColorEffect buttonEffect) {
-    ColorEffect colorEffect = ColorEffect.NONE;
+        if (isRowStyle()) {
+            // Centered vertically, centered horizontally with the icon text and spacing
+            x = width / 2 - contentWidth / 2 + iconTextSize.x + spacing;
+            y = height / 2 - textSize.y / 2;
+        } else {
+            // Centered horizontally, centered vertically with the icon text and spacing
+            x = width / 2 - textSize.x / 2;
+            y = height / 2 - contentHeight / 2 + iconTextSize.y + spacing;
+        }
 
-    switch (buttonEffect) {
-    case BRIGHTEN:
-    case BRIGHTEN_FOREGROUND:
-    case BRIGHTEN_FOREGROUND_DARKEN_BACKGROUND:
-      colorEffect = ColorEffect.BRIGHTEN;
-      break;
-    case DARKEN:
-    case DARKEN_FOREGROUND:
-      colorEffect = ColorEffect.DARKEN;
-      break;
-    case DESATURATE:
-    case DESATURATE_FOREGROUND:
-      colorEffect = ColorEffect.DESATURATE;
-      break;
-    case SHIFT:
-    case SHIFT_FOREGROUND:
-      colorEffect = ColorEffect.SHIFT;
-      break;
-    case NONE:
-    case BRIGHTEN_BACKGROUND:
-    case DARKEN_BACKGROUND:
-      // No foreground effect
-      break;
-    default:
-      log.warning("Unknown button effect: " + buttonEffect);
+        return new Rectangle(x, y, textSize.x, textSize.y);
     }
 
-    return button.getColorPalette().getColorWithEffect(colorLabel, colorEffect);
-  }
+    protected static void drawTextAtLocation(GC gc, String text, Font font, Color color, int x, int y) {
+        gc.setFont(font);
+        gc.setForeground(color);
+        gc.drawText(text, x, y, SWT.DRAW_TRANSPARENT | SWT.DRAW_DELIMITER);
+    }
+
+    /**
+     * Returns the preferred size of the receiver
+     *
+     * @param button
+     * @return
+     */
+    @Override
+    public Point computeSize(TextIconButton button) {
+        this.button = button;
+        this.style = button.getCurrentStyle();
+
+        updateSizes();
+
+        return size;
+    }
+
+    private int computeMinimumHeight(int textHeight, int iconTextHeight) {
+        int spacing = (textHeight > 0 && iconTextHeight > 0) ? style.getSpacing() : 0;
+        int baseHeight = 2 * style.getMargin() + 2 * style.getBorderWidth() + spacing;
+        int contentHeight = isRowStyle() ? Math.max(textHeight, iconTextHeight) : textHeight + iconTextHeight;
+        return baseHeight + contentHeight;
+    }
+
+    private int computeMinimumWidth(int textWidth, int iconTextWidth) {
+        int spacing = (textWidth > 0 && iconTextWidth > 0) ? style.getSpacing() : 0;
+        int baseWidth = 2 * style.getBorderWidth() + 2 * style.getMargin();
+        int contentWidth = isRowStyle() ? textWidth + iconTextWidth + spacing : Math.max(textWidth, iconTextWidth);
+        return baseWidth + contentWidth;
+    }
+
+    private Point computeTextSize() {
+        String text = button.getText();
+        return (text != null) ? getTextExtent(button, text, style.getFont()) : new Point(0, 0);
+    }
+
+    /**
+     * Returns the estimated size of the painted text icon.
+     * <p>
+     * Note: the current assumption is that the icon is centered and not offset
+     *
+     * @return
+     */
+    private Point computeTextIconSize() {
+        Point max = new Point(0, 0);
+        Point current;
+
+        for (TextIcon icon : button.getTextIcons()) {
+            current = getTextExtent(button, icon.getText(), FontFactory.getIconFont(icon.getFontSize()));
+
+            if (current.x > max.x) {
+                max.x = current.x;
+            }
+
+            if (current.y > max.y) {
+                max.y = current.y;
+            }
+        }
+
+        return max;
+    }
+
+    /**
+     * Returns the dimensions of the specified text in the given font
+     *
+     * @param button
+     * @param text
+     * @param font
+     * @return
+     */
+    protected Point getTextExtent(TextIconButton button, String text, Font font) {
+        final GC gc = new GC(button);
+        gc.setFont(font);
+
+        final Point size = gc.textExtent(text, SWT.DRAW_DELIMITER);
+        gc.dispose();
+
+        return size;
+    }
+
+    private boolean isBorderStyle() {
+        return style.getButtonEffects().contains(ButtonEffect.BORDER);
+    }
+
+    private boolean isRowStyle() {
+        // The row button style is the default if none is specified
+        return style.getButtonEffects().contains(ButtonEffect.ROW) || !style.getButtonEffects()
+                .contains(ButtonEffect.COLUMN);
+    }
+
+    private boolean isColumnStyle() {
+        return style.getButtonEffects().contains(ButtonEffect.COLUMN);
+    }
+
+    private boolean isTextDropShadowStyle(Set<ButtonEffect> buttonEffects) {
+        return buttonEffects.contains(ButtonEffect.TEXT_DROP_SHADOW);
+    }
+
+    private boolean isIconDropShadowStyle(Set<ButtonEffect> buttonEffects) {
+        return buttonEffects.contains(ButtonEffect.ICON_DROP_SHADOW);
+    }
+
+    private Color getBackgroundColor(String colorLabel, ButtonColorEffect buttonEffect) {
+        ColorEffect colorEffect = ColorEffect.NONE;
+
+        switch (buttonEffect) {
+            case BRIGHTEN:
+            case BRIGHTEN_BACKGROUND:
+                colorEffect = ColorEffect.BRIGHTEN;
+                break;
+            case DARKEN:
+            case DARKEN_BACKGROUND:
+            case BRIGHTEN_FOREGROUND_DARKEN_BACKGROUND:
+                colorEffect = ColorEffect.DARKEN;
+                break;
+            case DESATURATE:
+            case DESATURATE_BACKGROUND:
+                colorEffect = ColorEffect.DESATURATE;
+                break;
+            case SHIFT:
+            case SHIFT_BACKGROUND:
+                colorEffect = ColorEffect.SHIFT;
+                break;
+            case NONE:
+            case BRIGHTEN_FOREGROUND:
+            case DARKEN_FOREGROUND:
+            case DESATURATE_FOREGROUND:
+                // No background effect
+                break;
+            default:
+                log.warning("Unknown button effect: " + buttonEffect);
+        }
+
+        return button.getColorPalette().getColorWithEffect(colorLabel, colorEffect);
+    }
+
+    private Color getForegroundColor(String colorLabel, ButtonColorEffect buttonEffect) {
+        ColorEffect colorEffect = ColorEffect.NONE;
+
+        switch (buttonEffect) {
+            case BRIGHTEN:
+            case BRIGHTEN_FOREGROUND:
+            case BRIGHTEN_FOREGROUND_DARKEN_BACKGROUND:
+                colorEffect = ColorEffect.BRIGHTEN;
+                break;
+            case DARKEN:
+            case DARKEN_FOREGROUND:
+                colorEffect = ColorEffect.DARKEN;
+                break;
+            case DESATURATE:
+            case DESATURATE_FOREGROUND:
+                colorEffect = ColorEffect.DESATURATE;
+                break;
+            case SHIFT:
+            case SHIFT_FOREGROUND:
+                colorEffect = ColorEffect.SHIFT;
+                break;
+            case NONE:
+            case BRIGHTEN_BACKGROUND:
+            case DARKEN_BACKGROUND:
+                // No foreground effect
+                break;
+            default:
+                log.warning("Unknown button effect: " + buttonEffect);
+        }
+
+        return button.getColorPalette().getColorWithEffect(colorLabel, colorEffect);
+    }
 }


### PR DESCRIPTION
This change adds icon font loading failure fallback behavior:
- Only paints the text, not the icon
- Warns the developer the default fallback font is being used