### PR TITLE
Disabled font DPI scaling on Mac.  Fixed identification of Windows 7.

### DIFF
--- a/src/main/java/com/readytalk/swt/util/ClientOS.java
+++ b/src/main/java/com/readytalk/swt/util/ClientOS.java
@@ -10,7 +10,8 @@ public class ClientOS {
             double version;
             try {
                 version = Float.parseFloat(System.getProperty("os.version"));
-                windows7 = version <= 7.0;
+                //Windows 7 is internally identified as 6.1
+                windows7 = version <= 6.1;
             } catch (NumberFormatException ex) {
                 windows7 = true;
             }

--- a/src/main/java/com/readytalk/swt/util/FontFactory.java
+++ b/src/main/java/com/readytalk/swt/util/FontFactory.java
@@ -223,9 +223,15 @@ public enum FontFactory {
     // converts a "size" metric to the nearest system-dependent
     // "point" metric - based on DPIs
     private static int fontPoint(final Device dev, final int size) {
-        int systemDPI = dev.getDPI().y;
-        double ratio = (double) FONT_DPI / systemDPI;
-        return (int) (ratio * size);
+        //Do not apply DPI on mac, it displays best at 1:1 and reports
+        //DPI inconsistently.
+        String osName = System.getProperty(OS_NAME);
+        if (osName == null || osName.length() == 0 || !osName.startsWith(MAC)) {
+            int systemDPI = dev.getDPI().y;
+            double ratio = (double) FONT_DPI / systemDPI;
+            return (int) (ratio * size);
+        }
+        return size;
     }
 
     /**


### PR DESCRIPTION
The os.version for Windows 7 is returned as 6.1.  Windows 8+ come up as 6.2, so for conditionally not setting advanced mode, we need to use 6.1.