### PR TITLE
Jdk7 fix travis 7964

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: java
 jdk:
-- oraclejdk8
-- openjdk6
-# Workaround for buffer overflow with openjdk6
-# https://github.com/travis-ci/travis-ci/issues/5227
+- openjdk8
 addons:
+  # Workaround for buffer overflow with openjdk6
+  # https://github.com/travis-ci/travis-ci/issues/5227
   hosts:
     - myshorthost
   hostname: myshorthost
+  apt:
+    packages:
+      - openjdk-6-jdk
 env:
   global:
   - secure: TO3oA+i1BRv1eTyHlf2oD9v7Mlh+ZRI2qcy6+vbKvWwKhE97eIl24TBrRnivrAYvDSCb7LQbKfYdlylIAz1j2/sm69A3mwjAxRZetekLesRszy/cgc5FDmMh9x9KgOwDfJlVm8Z1uT2UwZ/AfEGFbLFPjHAcp4jbPgdJcUr2SuY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
 - oraclejdk8
-- oraclejdk7
 - openjdk6
 # Workaround for buffer overflow with openjdk6
 # https://github.com/travis-ci/travis-ci/issues/5227
@@ -17,6 +16,7 @@ env:
 before_install:
 - export TERM=dumb
 - export DISPLAY=:99.0
+- export JAVA6_HOME=/usr/lib/jvm/java-6-openjdk-amd64
 - sh -e /etc/init.d/xvfb start
 script: ./gradlew integTest check Javadoc --info --stacktrace
 after_success:

--- a/build.gradle
+++ b/build.gradle
@@ -97,16 +97,19 @@ compileJava {
   options.fork = true
 }
 
-task getVersion << {
-  println version
+tasks.withType(JavaCompile) {
+  sourceCompatibility = 1.6
+  targetCompatibility = 1.6
+  options.bootClasspath = "${System.env.JAVA6_HOME}/jre/lib/rt.jar"
+  options.bootClasspath += "${File.pathSeparator}${System.env.JAVA6_HOME}/jre/lib/jsse.jar"
 }
 
-if (JavaVersion.current().isJava8Compatible()) {
-  allprojects {
-    tasks.withType(Javadoc) {
-      options.addStringOption('Xdoclint:none', '-quiet')
-    }
-  }
+tasks.withType(Javadoc) {
+  options.addStringOption('Xdoclint:none', '-quiet')
+}
+
+task getVersion << {
+  println version
 }
 
 apply from: 'gradle/idea.gradle'


### PR DESCRIPTION
Build-only work around for the JDK7/JDK6 installer removals documented in https://github.com/travis-ci/travis-ci/issues/7964